### PR TITLE
New features for the Local To-Do Integration - Group 1

### DIFF
--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -30,6 +30,8 @@ export const enum TodoListEntityFeature {
   SET_DUE_DATE_ON_ITEM = 16,
   SET_DUE_DATETIME_ON_ITEM = 32,
   SET_DESCRIPTION_ON_ITEM = 64,
+  SORT_BY_DATE_ITEM = 128,
+  SORT_BY_PRIORITY_ITEM = 256,
 }
 
 export const getTodoLists = (hass: HomeAssistant): TodoList[] =>
@@ -43,6 +45,7 @@ export const getTodoLists = (hass: HomeAssistant): TodoList[] =>
       ...hass.states[entityId],
       entity_id: entityId,
       name: computeStateName(hass.states[entityId]),
+      priority: computeStateName(hass.states[entityId]),
     }))
     .sort((a, b) => stringCompare(a.name, b.name, hass.locale.language));
 
@@ -138,4 +141,22 @@ export const moveItem = (
     entity_id,
     uid,
     previous_uid,
+  });
+
+export const sortItemsByDate = (
+  hass: HomeAssistant,
+  entity_id: string
+): Promise<void> =>
+  hass.callWS({
+    type: "todo/item/sortDate",
+    entity_id,
+  });
+
+export const sortItemsByPriority = (
+  hass: HomeAssistant,
+  entity_id: string
+): Promise<void> =>
+  hass.callWS({
+    type: "todo/item/sortPriority",
+    entity_id,
   });

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -14,12 +14,20 @@ export const enum TodoItemStatus {
   Completed = "completed",
 }
 
+// The priority for a todo item.
+export const enum TodoItemPriority {
+  LOW = "low",
+  MEDIUM = "medium",
+  HIGH = "high",
+}
+
 export interface TodoItem {
   uid: string;
   summary: string;
   status: TodoItemStatus;
   description?: string | null;
   due?: string | null;
+  priority?: TodoItemPriority | null;
 }
 
 export const enum TodoListEntityFeature {
@@ -89,6 +97,7 @@ export const updateItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
+      priority: item.priority,
     },
     { entity_id }
   );
@@ -109,6 +118,7 @@ export const createItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
+      priority: item.priority || TodoItemPriority.MEDIUM,
     },
     { entity_id }
   );

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -38,6 +38,7 @@ export const enum TodoListEntityFeature {
   SET_DUE_DATE_ON_ITEM = 16,
   SET_DUE_DATETIME_ON_ITEM = 32,
   SET_DESCRIPTION_ON_ITEM = 64,
+  SET_PRIORITY_ON_ITEM = 512,
 }
 
 export const getTodoLists = (hass: HomeAssistant): TodoList[] =>
@@ -118,7 +119,7 @@ export const createItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
-      priority: item.priority || TodoItemPriority.MEDIUM,
+      priority: item.priority || undefined,
     },
     { entity_id }
   );

--- a/src/data/todo.ts
+++ b/src/data/todo.ts
@@ -15,10 +15,10 @@ export const enum TodoItemStatus {
 }
 
 // The priority for a todo item.
-export const enum TodoItemPriority {
-  LOW = "low",
-  MEDIUM = "medium",
-  HIGH = "high",
+export const enum TodoPriority {
+  low = "low",
+  medium = "medium",
+  high = "high",
 }
 
 export interface TodoItem {
@@ -27,7 +27,7 @@ export interface TodoItem {
   status: TodoItemStatus;
   description?: string | null;
   due?: string | null;
-  priority?: TodoItemPriority | null;
+  priority?: TodoPriority | TodoPriority.medium;
 }
 
 export const enum TodoListEntityFeature {
@@ -98,7 +98,7 @@ export const updateItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
-      priority: item.priority,
+      priority: item.priority ?? undefined,
     },
     { entity_id }
   );
@@ -119,7 +119,7 @@ export const createItem = (
         item.due === undefined || item.due?.includes("T")
           ? undefined
           : item.due,
-      priority: item.priority || undefined,
+      priority: item.priority ?? undefined,
     },
     { entity_id }
   );

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -8,6 +8,7 @@ import {
   mdiDrag,
   mdiPlus,
   mdiSort,
+  mdiSortVariant,
 } from "@mdi/js";
 import { endOfDay, isSameDay } from "date-fns";
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
@@ -261,6 +262,15 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                             <ha-svg-icon
                               slot="graphic"
                               .path=${mdiSort}
+                              .disabled=${unavailable}
+                            >
+                            </ha-svg-icon>
+                          </ha-list-item>
+                          <ha-list-item @click=${this._autoSort} graphic="icon">
+                            Sort Automatically
+                            <ha-svg-icon
+                              slot="graphic"
+                              .path=${mdiSortVariant}
                               .disabled=${unavailable}
                             >
                             </ha-svg-icon>
@@ -553,6 +563,12 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
 
   private async _toggleReorder() {
     this._reordering = !this._reordering;
+  }
+
+  private async _autoSort() {
+    console.log("auto sort");
+
+    //TODO: connect the autosort service from core
   }
 
   private async _itemMoved(ev: CustomEvent) {

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -47,6 +47,8 @@ import {
   createItem,
   deleteItems,
   moveItem,
+  sortItemsByDate,
+  sortItemsByPriority,
   subscribeItems,
   updateItem,
 } from "../../../data/todo";
@@ -268,7 +270,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
 
                           ${!this._reordering
                             ? html` <ha-list-item
-                                @click=${this._toggleReorder}
+                                @click=${this._sortByPriority}
                                 graphic="icon"
                               >
                                 ${this.hass!.localize(
@@ -285,7 +287,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                           ${!this._reordering
                             ? html`
                           <ha-list-item
-                            @click=${this._toggleReorder}
+                            @click=${this._sortByDate}
                             graphic="icon"
                           >
                             ${this.hass!.localize(
@@ -596,6 +598,14 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
     ev.stopPropagation();
     const { oldIndex, newIndex } = ev.detail;
     this._moveItem(oldIndex, newIndex);
+  }
+
+  private async _sortByDate() {
+    await sortItemsByDate(this.hass!, this._entityId!);
+  }
+
+  private async _sortByPriority() {
+    await sortItemsByPriority(this.hass!, this._entityId!);
   }
 
   private async _moveItem(oldIndex: number, newIndex: number) {

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -329,13 +329,6 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
         (item) => item.uid,
         (item) => {
           const showDelete = true;
-          // this.todoListSupportsFeature(
-          //   TodoListEntityFeature.DELETE_TODO_ITEM
-          // ) &&
-          // !this.todoListSupportsFeature(
-          //   TodoListEntityFeature.UPDATE_TODO_ITEM
-          // );
-
           const showReorder =
             item.status !== TodoItemStatus.Completed && this._reordering;
           const due = item.due

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -328,13 +328,14 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
         items,
         (item) => item.uid,
         (item) => {
-          const showDelete =
-            this.todoListSupportsFeature(
-              TodoListEntityFeature.DELETE_TODO_ITEM
-            ) &&
-            !this.todoListSupportsFeature(
-              TodoListEntityFeature.UPDATE_TODO_ITEM
-            );
+          const showDelete = true;
+          // this.todoListSupportsFeature(
+          //   TodoListEntityFeature.DELETE_TODO_ITEM
+          // ) &&
+          // !this.todoListSupportsFeature(
+          //   TodoListEntityFeature.UPDATE_TODO_ITEM
+          // );
+
           const showReorder =
             item.status !== TodoItemStatus.Completed && this._reordering;
           const due = item.due
@@ -404,7 +405,7 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                       .title=${this.hass!.localize(
                         "ui.panel.lovelace.cards.todo-list.delete_item"
                       )}
-                      class="deleteItemButton"
+                      class="deleteItemButton red-accent"
                       .path=${mdiDelete}
                       .itemId=${item.uid}
                       slot="meta"
@@ -758,6 +759,10 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
       }
 
       .warning {
+        color: var(--error-color);
+      }
+
+      .red-accent {
         color: var(--error-color);
       }
     `;

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -267,7 +267,9 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                             </ha-svg-icon>
                           </ha-list-item>
                           <ha-list-item @click=${this._autoSort} graphic="icon">
-                            Sort Automatically
+                            ${this.hass!.localize(
+                              "ui.panel.lovelace.cards.todo-list.sort_automatically"
+                            )}
                             <ha-svg-icon
                               slot="graphic"
                               .path=${mdiSortVariant}
@@ -563,12 +565,6 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
 
   private async _toggleReorder() {
     this._reordering = !this._reordering;
-  }
-
-  private async _autoSort() {
-    console.log("auto sort");
-
-    //TODO: connect the autosort service from core
   }
 
   private async _itemMoved(ev: CustomEvent) {

--- a/src/panels/lovelace/cards/hui-todo-list-card.ts
+++ b/src/panels/lovelace/cards/hui-todo-list-card.ts
@@ -265,7 +265,38 @@ export class HuiTodoListCard extends LitElement implements LovelaceCard {
                             >
                             </ha-svg-icon>
                           </ha-list-item>
+
+                          ${!this._reordering
+                            ? html` <ha-list-item
+                                @click=${this._toggleReorder}
+                                graphic="icon"
+                              >
+                                ${this.hass!.localize(
+                                  "ui.panel.lovelace.cards.todo-list.sort_by_priority"
+                                )}
+                                <ha-svg-icon
+                                  slot="graphic"
+                                  .path=${mdiSort}
+                                  .disabled=${unavailable}
+                                >
+                                </ha-svg-icon>
+                              </ha-list-item>`
+                            : nothing}
+                          ${!this._reordering
+                            ? html`
+                          <ha-list-item
+                            @click=${this._toggleReorder}
+                            graphic="icon"
+                          >
+                            ${this.hass!.localize(
+                              "ui.panel.lovelace.cards.todo-list.sort_by_date"
+                            )}
+                            <ha-svg-icon slot="graphic" .path=${mdiSort}>
+                            </ha-svg-icon>
+                          </ha-list-item>
                         </ha-button-menu>`
+                            : nothing}</ha-button-menu
+                        >`
                       : nothing}
                   </div>
                   ${this._renderItems(uncheckedItems, unavailable)}

--- a/src/panels/todo/dialog-todo-item-editor.ts
+++ b/src/panels/todo/dialog-todo-item-editor.ts
@@ -141,11 +141,11 @@ class DialogTodoItemEditor extends LitElement {
               .disabled=${!canUpdate}
             ></ha-textfield>
           </div>
-          ${this._todoListSupportsFeature(
-            TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
-          )
-            ? html` <div class="flex-row">
-                <ha-textarea
+          <div class="flex-row">
+            ${this._todoListSupportsFeature(
+              TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
+            )
+              ? html` <ha-textarea
                   class="description"
                   name="description"
                   .label=${this.hass.localize(
@@ -155,8 +155,12 @@ class DialogTodoItemEditor extends LitElement {
                   @input=${this._handleDescriptionChanged}
                   autogrow
                   .disabled=${!canUpdate}
-                ></ha-textarea>
-                <div class="priority-column">
+                ></ha-textarea>`
+              : nothing}
+            ${this._todoListSupportsFeature(
+              TodoListEntityFeature.SET_PRIORITY_ON_ITEM
+            )
+              ? html` <div class="priority-column">
                   <span class="priority-label">Priority:</span>
                   <ha-select
                     class="priority"
@@ -169,13 +173,19 @@ class DialogTodoItemEditor extends LitElement {
                     @closed=${stopPropagation}
                     .disabled=${!canUpdate}
                   >
-                    <mwc-list-item value="LOW">LOW</mwc-list-item>
-                    <mwc-list-item value="MEDIUM">MEDIUM</mwc-list-item>
-                    <mwc-list-item value="HIGH">HIGH</mwc-list-item>
+                    <mwc-list-item value=${TodoItemPriority.LOW}
+                      >LOW</mwc-list-item
+                    >
+                    <mwc-list-item value=${TodoItemPriority.MEDIUM}
+                      >MEDIUM</mwc-list-item
+                    >
+                    <mwc-list-item value=${TodoItemPriority.HIGH}
+                      >HIGH</mwc-list-item
+                    >
                   </ha-select>
-                </div>
-              </div>`
-            : nothing}
+                </div>`
+              : nothing}
+          </div>
           ${this._todoListSupportsFeature(
             TodoListEntityFeature.SET_DUE_DATE_ON_ITEM
           ) ||

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -5383,6 +5383,8 @@
             "today": "Today",
             "reorder_items": "Reorder items",
             "exit_reorder_items": "Exit reorder mode",
+            "sort_by_date": "Sort by date",
+            "sort_by_priority": "Sort by priority",
             "drag_and_drop": "Drag and drop",
             "delete_item": "Delete item",
             "delete_confirm_title": "Remove completed items?",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -909,7 +909,11 @@
           "confirm_delete": {
             "delete": "Delete item",
             "prompt": "Do you want to delete this item?"
-          }
+          },
+          "select_priority": "Select priority",
+          "low_priority": "LOW",
+          "medium_priority": "MEDIUM",
+          "high_priority": "HIGH"
         }
       },
       "calendar": {
@@ -5386,7 +5390,8 @@
             "drag_and_drop": "Drag and drop",
             "delete_item": "Delete item",
             "delete_confirm_title": "Remove completed items?",
-            "delete_confirm_text": "{number} {number, plural,\n  one {item}\n  other {items}\n} will be permanently removed from the to-do list."
+            "delete_confirm_text": "{number} {number, plural,\n  one {item}\n  other {items}\n} will be permanently removed from the to-do list.",
+            "sort_automatically": "Sort automatically"
           },
           "picture-elements": {
             "hold": "Hold:",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue or discussion
  in the additional information section.
-->
New features were added to the Local To-do Integration. A PR has also been created to the core repository.
The new features are: the addition of a priority criteria for each To-Do Item inside of a To-Do list (both core and frontend), the possibility to sort the To-Do List either by date or by priority (both core and frontend), and simplify the deletion of items by adding a delete icon next to the item (frontend only).

Tests have been written to test those new features, as well as checking that all the other integration using the To-Do entity doesn't have any problem with the addition of the priority attribute to a To-Do Item.

## Type of change
<!--
  What type of change does your PR introduce to the Home Assistant frontend?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (thank you!)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue or discussion:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  Thank you for contributing <3
-->

[docs-repository]: https://github.com/home-assistant/home-assistant.io
